### PR TITLE
SLING-10456 adjust HTTP status code for invalid :redirect value for usermanager post requests

### DIFF
--- a/src/test/java/org/apache/sling/jcr/jackrabbit/usermanager/it/post/CreateGroupIT.java
+++ b/src/test/java/org/apache/sling/jcr/jackrabbit/usermanager/it/post/CreateGroupIT.java
@@ -182,4 +182,29 @@ public class CreateGroupIT extends UserManagerClientTestSupport {
         assertNotNull(jsonObj);
     }
 
+    private void testCreateGroupRedirect(String redirectTo, int expectedStatus) throws IOException {
+        String postUrl = String.format("%s/system/userManager/group.create.html", baseServerUri);
+
+        testGroupId = "testGroup" + getNextInt();
+        List<NameValuePair> postParams = new ArrayList<>();
+        postParams.add(new BasicNameValuePair(":name", testGroupId));
+        postParams.add(new BasicNameValuePair(":redirect", redirectTo));
+        assertAuthenticatedAdminPostStatus(postUrl, expectedStatus, postParams, null);
+    }
+
+    @Test
+    public void testCreateGroupValidRedirect() throws IOException, JsonException {
+        testCreateGroupRedirect("/*.html", HttpServletResponse.SC_MOVED_TEMPORARILY);
+    }
+
+    @Test
+    public void testCreateGroupInvalidRedirectWithAuthority() throws IOException, JsonException {
+        testCreateGroupRedirect("https://sling.apache.org", SC_UNPROCESSABLE_ENTITY);
+    }
+
+    @Test
+    public void testCreateGroupInvalidRedirectWithInvalidURI() throws IOException, JsonException {
+        testCreateGroupRedirect("https://", SC_UNPROCESSABLE_ENTITY);
+    }
+
 }

--- a/src/test/java/org/apache/sling/jcr/jackrabbit/usermanager/it/post/CreateUserIT.java
+++ b/src/test/java/org/apache/sling/jcr/jackrabbit/usermanager/it/post/CreateUserIT.java
@@ -277,4 +277,30 @@ public class CreateUserIT extends UserManagerClientTestSupport {
         assertEquals("Thanks!", content); //verify that the content matches the custom response
     }
 
+    private void testCreateUserRedirect(String redirectTo, int expectedStatus) throws IOException {
+        testUserId = "testUser" + getNextInt();
+        String postUrl = String.format("%s/system/userManager/user.create.html", baseServerUri);
+        final List<NameValuePair> postParams = new ArrayList<>();
+        postParams.add(new BasicNameValuePair(":name", testUserId));
+        postParams.add(new BasicNameValuePair("pwd", "testPwd"));
+        postParams.add(new BasicNameValuePair("pwdConfirm", "testPwd"));
+        postParams.add(new BasicNameValuePair(":redirect", redirectTo));
+        assertAuthenticatedAdminPostStatus(postUrl, expectedStatus, postParams, null);
+    }
+
+    @Test
+    public void testCreateUserValidRedirect() throws IOException, JsonException {
+        testCreateUserRedirect("/*.html", HttpServletResponse.SC_MOVED_TEMPORARILY);
+    }
+
+    @Test
+    public void testCreateUserInvalidRedirectWithAuthority() throws IOException, JsonException {
+        testCreateUserRedirect("https://sling.apache.org", SC_UNPROCESSABLE_ENTITY);
+    }
+
+    @Test
+    public void testCreateUserInvalidRedirectWithInvalidURI() throws IOException, JsonException {
+        testCreateUserRedirect("https://", SC_UNPROCESSABLE_ENTITY);
+    }
+
 }

--- a/src/test/java/org/apache/sling/jcr/jackrabbit/usermanager/it/post/RemoveAuthorizablesIT.java
+++ b/src/test/java/org/apache/sling/jcr/jackrabbit/usermanager/it/post/RemoveAuthorizablesIT.java
@@ -260,4 +260,31 @@ public class RemoveAuthorizablesIT extends UserManagerClientTestSupport {
         assertNotNull(jsonObj);
     }
 
+    private void testRemoveAuthorizablesRedirect(String redirectTo, int expectedStatus) throws IOException {
+        String userId = createTestUser();
+        String groupId = createTestGroup();
+
+        String postUrl = String.format("%s/system/userManager.delete.html", baseServerUri);
+        List<NameValuePair> postParams = new ArrayList<>();
+        postParams.add(new BasicNameValuePair(":applyTo", "group/" + groupId));
+        postParams.add(new BasicNameValuePair(":applyTo", "user/" + userId));
+        postParams.add(new BasicNameValuePair(":redirect", redirectTo));
+        assertAuthenticatedAdminPostStatus(postUrl, expectedStatus, postParams, null);
+    }
+
+    @Test
+    public void testRemoveAuthorizableValidRedirect() throws IOException, JsonException {
+        testRemoveAuthorizablesRedirect("/*.html", HttpServletResponse.SC_MOVED_TEMPORARILY);
+    }
+
+    @Test
+    public void testRemoveAuthorizableInvalidRedirectWithAuthority() throws IOException, JsonException {
+        testRemoveAuthorizablesRedirect("https://sling.apache.org", SC_UNPROCESSABLE_ENTITY);
+    }
+
+    @Test
+    public void testRemoveAuthorizableInvalidRedirectWithInvalidURI() throws IOException, JsonException {
+        testRemoveAuthorizablesRedirect("https://", SC_UNPROCESSABLE_ENTITY);
+    }
+
 }

--- a/src/test/java/org/apache/sling/jcr/jackrabbit/usermanager/it/post/UpdateGroupIT.java
+++ b/src/test/java/org/apache/sling/jcr/jackrabbit/usermanager/it/post/UpdateGroupIT.java
@@ -258,5 +258,33 @@ public class UpdateGroupIT extends UserManagerClientTestSupport {
         assertNotNull(jsonObj);
     }
 
+    private void testUpdateGroupRedirect(String redirectTo, int expectedStatus) throws IOException {
+        testGroupId = createTestGroup();
+
+        String postUrl = String.format("%s/system/userManager/group/%s.update.html", baseServerUri, testGroupId);
+
+        List<NameValuePair> postParams = new ArrayList<>();
+        postParams.add(new BasicNameValuePair("displayName", "My Updated Test Group"));
+        postParams.add(new BasicNameValuePair(":redirect", redirectTo));
+
+        Credentials creds = new UsernamePasswordCredentials("admin", "admin");
+        assertAuthenticatedPostStatus(creds, postUrl, expectedStatus, postParams, null);
+    }
+
+    @Test
+    public void testUpdateGroupValidRedirect() throws IOException, JsonException {
+        testUpdateGroupRedirect("/*.html", HttpServletResponse.SC_MOVED_TEMPORARILY);
+    }
+
+    @Test
+    public void testUpdateGroupInvalidRedirectWithAuthority() throws IOException, JsonException {
+        testUpdateGroupRedirect("https://sling.apache.org", SC_UNPROCESSABLE_ENTITY);
+    }
+
+    @Test
+    public void testUpdateGroupInvalidRedirectWithInvalidURI() throws IOException, JsonException {
+        testUpdateGroupRedirect("https://", SC_UNPROCESSABLE_ENTITY);
+    }
+
 }
 

--- a/src/test/java/org/apache/sling/jcr/jackrabbit/usermanager/it/post/UpdateUserIT.java
+++ b/src/test/java/org/apache/sling/jcr/jackrabbit/usermanager/it/post/UpdateUserIT.java
@@ -376,4 +376,61 @@ public class UpdateUserIT extends UserManagerClientTestSupport {
         httpContext.getCookieStore().clear();
     }
 
+    private void testChangeUserPasswordRedirect(String redirectTo, int expectedStatus) throws IOException {
+        testUserId = createTestUser();
+
+        String postUrl = String.format("%s/system/userManager/user/%s.changePassword.html", baseServerUri, testUserId);
+
+        List<NameValuePair> postParams = new ArrayList<>();
+        postParams.add(new BasicNameValuePair("oldPwd", "testPwd"));
+        postParams.add(new BasicNameValuePair("newPwd", "testNewPwd"));
+        postParams.add(new BasicNameValuePair("newPwdConfirm", "testNewPwd"));
+        postParams.add(new BasicNameValuePair(":redirect", redirectTo));
+
+        Credentials creds = new UsernamePasswordCredentials(testUserId, "testPwd");
+        assertAuthenticatedPostStatus(creds, postUrl, expectedStatus, postParams, null);
+    }
+
+    @Test
+    public void testChangeUserPasswordValidRedirect() throws IOException, JsonException {
+        testChangeUserPasswordRedirect("/*.html", HttpServletResponse.SC_MOVED_TEMPORARILY);
+    }
+
+    @Test
+    public void testChangeUserPasswordInvalidRedirectWithAuthority() throws IOException, JsonException {
+        testChangeUserPasswordRedirect("https://sling.apache.org", SC_UNPROCESSABLE_ENTITY);
+    }
+
+    @Test
+    public void testChangeUserPasswordInvalidRedirectWithInvalidURI() throws IOException, JsonException {
+        testChangeUserPasswordRedirect("https://", SC_UNPROCESSABLE_ENTITY);
+    }
+
+    private void testUpdateUserRedirect(String redirectTo, int expectedStatus) throws IOException {
+        testUserId = createTestUser();
+
+        String postUrl = String.format("%s/system/userManager/user/%s.update.html", baseServerUri, testUserId);
+
+        List<NameValuePair> postParams = new ArrayList<>();
+        postParams.add(new BasicNameValuePair("displayName", "My Updated Test User"));
+        postParams.add(new BasicNameValuePair(":redirect", redirectTo));
+        Credentials creds = new UsernamePasswordCredentials(testUserId, "testPwd");
+        assertAuthenticatedPostStatus(creds, postUrl, expectedStatus, postParams, null);
+    }
+
+    @Test
+    public void testUpdateUserValidRedirect() throws IOException, JsonException {
+        testUpdateUserRedirect("/*.html", HttpServletResponse.SC_MOVED_TEMPORARILY);
+    }
+
+    @Test
+    public void testUpdateUserInvalidRedirectWithAuthority() throws IOException, JsonException {
+        testUpdateUserRedirect("https://sling.apache.org", SC_UNPROCESSABLE_ENTITY);
+    }
+
+    @Test
+    public void testUpdateUserInvalidRedirectWithInvalidURI() throws IOException, JsonException {
+        testUpdateUserRedirect("https://", SC_UNPROCESSABLE_ENTITY);
+    }
+
 }

--- a/src/test/java/org/apache/sling/jcr/jackrabbit/usermanager/it/post/UserManagerClientTestSupport.java
+++ b/src/test/java/org/apache/sling/jcr/jackrabbit/usermanager/it/post/UserManagerClientTestSupport.java
@@ -86,6 +86,8 @@ import org.osgi.service.cm.ConfigurationAdmin;
  * servlets
  */
 public abstract class UserManagerClientTestSupport extends UserManagerTestSupport {
+    protected static final int SC_UNPROCESSABLE_ENTITY = 422; // http status code for 422 Unprocessable Entity
+
     protected static final String TEST_FOLDER_JSON = "{'jcr:primaryType': 'nt:unstructured'}";
 
     protected static final String CONTENT_TYPE_JSON = "application/json";


### PR DESCRIPTION
When the usermanager servlets receive an illegal or invalid :redirect parameter it should return a status code of 422 instead of 200 because the request was not fully successful.

Currently, the illegal :redirect parameter value is detected and a warning is logged.  The request continues to be processed without the redirect occurring.  The client has no indication that something went wrong without reviewing the server logs.

