### PR TITLE
SLING-11098 Provide resource for the everyone group

### DIFF
--- a/src/main/java/org/apache/sling/jackrabbit/usermanager/impl/resource/AuthorizableResource.java
+++ b/src/main/java/org/apache/sling/jackrabbit/usermanager/impl/resource/AuthorizableResource.java
@@ -25,9 +25,7 @@ import org.apache.jackrabbit.api.security.user.Group;
 import org.apache.jackrabbit.api.security.user.User;
 import org.apache.sling.adapter.annotations.Adaptable;
 import org.apache.sling.adapter.annotations.Adapter;
-import org.apache.sling.api.resource.AbstractResource;
 import org.apache.sling.api.resource.Resource;
-import org.apache.sling.api.resource.ResourceMetadata;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ValueMap;
 import org.apache.sling.jackrabbit.usermanager.resource.SystemUserManagerPaths;
@@ -40,27 +38,19 @@ import org.apache.sling.jackrabbit.usermanager.resource.SystemUserManagerPaths;
     @Adapter(condition="If the resource is an AuthorizableResource and represents a JCR User", value = User.class),
     @Adapter(condition="If the resource is an AuthorizableResource and represents a JCR Group", value = Group.class)
 })
-public class AuthorizableResource extends AbstractResource {
-    protected final ResourceResolver resourceResolver;
+public class AuthorizableResource extends BaseResource {
     protected final Authorizable authorizable;
-    private final String path;
     private final String resourceType;
-    private final ResourceMetadata metadata;
     protected final SystemUserManagerPaths systemUserManagerPaths;
 
     public AuthorizableResource(Authorizable authorizable,
             ResourceResolver resourceResolver, String path,
             SystemUserManagerPaths systemUserManagerPaths) {
-        super();
+        super(resourceResolver, path);
 
-        this.resourceResolver = resourceResolver;
         this.authorizable = authorizable;
-        this.path = path;
         this.systemUserManagerPaths = systemUserManagerPaths;
         this.resourceType = toResourceType(authorizable);
-
-        this.metadata = new ResourceMetadata();
-        metadata.setResolutionPath(path);
     }
 
     /**
@@ -74,38 +64,6 @@ public class AuthorizableResource extends AbstractResource {
         } else {
             return "sling/user";
         }
-    }
-
-    /*
-     * (non-Javadoc)
-     * @see org.apache.sling.api.resource.Resource#getPath()
-     */
-    public String getPath() {
-        return path;
-    }
-
-    /*
-     * (non-Javadoc)
-     * @see org.apache.sling.api.resource.Resource#getResourceMetadata()
-     */
-    public ResourceMetadata getResourceMetadata() {
-        return metadata;
-    }
-
-    /*
-     * (non-Javadoc)
-     * @see org.apache.sling.api.resource.Resource#getResourceResolver()
-     */
-    public ResourceResolver getResourceResolver() {
-        return resourceResolver;
-    }
-
-    /*
-     * (non-Javadoc)
-     * @see org.apache.sling.api.resource.Resource#getResourceSuperType()
-     */
-    public String getResourceSuperType() {
-        return null;
     }
 
     /*

--- a/src/main/java/org/apache/sling/jackrabbit/usermanager/impl/resource/AuthorizableResourceProvider.java
+++ b/src/main/java/org/apache/sling/jackrabbit/usermanager/impl/resource/AuthorizableResourceProvider.java
@@ -212,12 +212,10 @@ public class AuthorizableResourceProvider extends ResourceProvider<Object> imple
             }
             return result;
         };
-        PrincipalWorker<Resource> principalWorker = principal -> {
-            // found the Principal, so return the resource
-            // that wraps it.
-            return new PrincipalResource(principal,
-                            ctx.getResourceResolver(), path);
-        };
+        // found the Principal, so return the resource
+        // that wraps it.
+        PrincipalWorker<Resource> principalWorker = principal -> new PrincipalResource(principal,
+                ctx.getResourceResolver(), path);
         return maybeDoAuthorizableWork(ctx, path, authorizableWorker, principalWorker);
     }
 

--- a/src/main/java/org/apache/sling/jackrabbit/usermanager/impl/resource/AuthorizableResourceProvider.java
+++ b/src/main/java/org/apache/sling/jackrabbit/usermanager/impl/resource/AuthorizableResourceProvider.java
@@ -26,6 +26,7 @@ import java.util.NoSuchElementException;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 
+import org.apache.jackrabbit.api.security.principal.GroupPrincipal;
 import org.apache.jackrabbit.api.security.principal.PrincipalIterator;
 import org.apache.jackrabbit.api.security.principal.PrincipalManager;
 import org.apache.jackrabbit.api.security.user.Authorizable;
@@ -190,7 +191,7 @@ public class AuthorizableResourceProvider extends ResourceProvider<Object> imple
             return new SyntheticResource(ctx.getResourceResolver(), path, "sling/groups");
         }
 
-        AuthorizableWorker<Resource> worker = (authorizable, relPath) -> {
+        AuthorizableWorker<Resource> authorizableWorker = (authorizable, relPath) -> {
             Resource result = null;
             // found the Authorizable, so return the resource
             // that wraps it.
@@ -211,14 +212,21 @@ public class AuthorizableResourceProvider extends ResourceProvider<Object> imple
             }
             return result;
         };
-        return maybeDoAuthorizableWork(ctx, path, worker);
+        PrincipalWorker<Resource> principalWorker = principal -> {
+            // found the Principal, so return the resource
+            // that wraps it.
+            return new PrincipalResource(principal,
+                            ctx.getResourceResolver(), path);
+        };
+        return maybeDoAuthorizableWork(ctx, path, authorizableWorker, principalWorker);
     }
 
     /**
      * If the path resolves to a user or group (with optional relPath suffix)
      * then invoke the worker to do some work.
      */
-    protected <T> T maybeDoAuthorizableWork(@NotNull ResolveContext<Object> ctx, @NotNull String path, @NotNull AuthorizableWorker<T> worker) {
+    protected <T> T maybeDoAuthorizableWork(@NotNull ResolveContext<Object> ctx, @NotNull String path, 
+            @NotNull AuthorizableWorker<T> authorizableWorker, @Nullable PrincipalWorker<T> principalWorker) {
         T result = null;
         // the principalId should be the first segment after the prefix
         String suffix = null;
@@ -246,7 +254,17 @@ public class AuthorizableResourceProvider extends ResourceProvider<Object> imple
                     if (userManager != null) {
                         Authorizable authorizable = userManager.getAuthorizable(pid);
                         if (authorizable != null) {
-                            result = worker.doWork(authorizable, relPath);
+                            result = authorizableWorker.doWork(authorizable, relPath);
+                        } else if (principalWorker != null && relPath == null){
+                            // SLING-11098 check for a principal that is not an authorizable like the everyone group
+                            PrincipalManager principalManager = AccessControlUtil.getPrincipalManager(session);
+                            if (principalManager != null) {
+                                @Nullable
+                                Principal principal = principalManager.getPrincipal(pid);
+                                if (principal != null) {
+                                    result = principalWorker.doWork(principal);
+                                }
+                            }
                         }
                     }
                 } catch (RepositoryException re) {
@@ -311,7 +329,7 @@ public class AuthorizableResourceProvider extends ResourceProvider<Object> imple
             } else if (resourcesForNestedProperties) {
                 // handle nested property containers
 
-                AuthorizableWorker<Iterator<Resource>> worker = (authorizable, relPath) -> {
+                AuthorizableWorker<Iterator<Resource>> authorizableWorker = (authorizable, relPath) -> {
                     Iterator<Resource> result = null;
                     Resource r = ctx.getResourceResolver().resolve(authorizable.getPath());
                     if (relPath != null) {
@@ -326,7 +344,7 @@ public class AuthorizableResourceProvider extends ResourceProvider<Object> imple
                     }
                     return result;
                 };
-                return maybeDoAuthorizableWork(ctx, path, worker);
+                return maybeDoAuthorizableWork(ctx, path, authorizableWorker, null);
             }
         } catch (RepositoryException re) {
             throw new SlingException("Error listing children of resource: "
@@ -393,25 +411,32 @@ public class AuthorizableResourceProvider extends ResourceProvider<Object> imple
                 ResourceResolver resourceResolver = parent.getResourceResolver();
                 Session session = resourceResolver.adaptTo(Session.class);
                 if (session != null) {
-                    UserManager userManager = AccessControlUtil.getUserManager(session);
-                    if (userManager != null) {
-                        Authorizable authorizable = userManager.getAuthorizable(principalName);
-                        if (authorizable != null) {
-                            String path;
-                            if (authorizable.isGroup()) {
-                                path = systemUserManagerGroupPrefix
-                                    + principalName;
-                            } else {
-                                path = systemUserManagerUserPrefix
-                                    + principalName;
-                            }
-                            next = createNext(child, resourceResolver, authorizable, path);
-                        }
-                    }
+                    next = createNext(child, principalName, resourceResolver, session);
                 }
             } catch (RepositoryException re) {
                 log.error("Exception while looking up authorizable resource.",
                     re);
+            }
+            return next;
+        }
+
+        protected @Nullable Resource createNext(Object child, String principalName,
+                ResourceResolver resourceResolver, Session session) throws RepositoryException {
+            Resource next = null;
+            UserManager userManager = AccessControlUtil.getUserManager(session);
+            if (userManager != null) {
+                Authorizable authorizable = userManager.getAuthorizable(principalName);
+                if (authorizable != null) {
+                    String path;
+                    if (authorizable.isGroup()) {
+                        path = systemUserManagerGroupPrefix
+                            + principalName;
+                    } else {
+                        path = systemUserManagerUserPrefix
+                            + principalName;
+                    }
+                    next = createNext(child, resourceResolver, authorizable, path);
+                }
             }
             return next;
         }
@@ -476,6 +501,34 @@ public class AuthorizableResourceProvider extends ResourceProvider<Object> imple
         }
 
         @Override
+        protected @Nullable Resource createNext(Object child, String principalName, ResourceResolver resourceResolver,
+                Session session) throws RepositoryException {
+            @Nullable
+            Resource next = super.createNext(child, principalName, resourceResolver, session);
+            if (next == null) {
+                // SLING-11098 check for principal that is not authorizable
+                PrincipalManager principalManager = AccessControlUtil.getPrincipalManager(session);
+                if (principalManager != null) {
+                    @Nullable
+                    Principal principal = principalManager.getPrincipal(principalName);
+                    if (principal != null) {
+                        String path;
+                        if (principal instanceof GroupPrincipal) {
+                            path = systemUserManagerGroupPrefix
+                                + principalName;
+                        } else {
+                            path = systemUserManagerUserPrefix
+                                + principalName;
+                        }
+                        return new PrincipalResource(principal,
+                                resourceResolver, path);
+                    }
+                }
+            }
+            return next;
+        }
+
+        @Override
         protected Resource createNext(Object child, ResourceResolver resourceResolver, Authorizable authorizable,
                 String path) throws RepositoryException {
             return new AuthorizableResource(authorizable,
@@ -492,4 +545,10 @@ public class AuthorizableResourceProvider extends ResourceProvider<Object> imple
         public T doWork(@NotNull Authorizable authorizable, @Nullable String relPath) throws RepositoryException;
     }
 
+    /**
+     * Interface for lambda expressions to do work on a resolved principal
+     */
+    protected static interface PrincipalWorker<T> {
+        public T doWork(@NotNull Principal principal) throws RepositoryException;
+    }
 }

--- a/src/main/java/org/apache/sling/jackrabbit/usermanager/impl/resource/BaseResource.java
+++ b/src/main/java/org/apache/sling/jackrabbit/usermanager/impl/resource/BaseResource.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.sling.jackrabbit.usermanager.impl.resource;
+
+import org.apache.sling.api.resource.AbstractResource;
+import org.apache.sling.api.resource.ResourceMetadata;
+import org.apache.sling.api.resource.ResourceResolver;
+
+/**
+ * Base Resource implementation for the common parts
+ */
+public abstract class BaseResource extends AbstractResource {
+    protected final ResourceResolver resourceResolver;
+    private final String path;
+    private final ResourceMetadata metadata;
+
+    public BaseResource(ResourceResolver resourceResolver, String path) {
+        super();
+
+        this.resourceResolver = resourceResolver;
+        this.path = path;
+
+        this.metadata = new ResourceMetadata();
+        metadata.setResolutionPath(path);
+    }
+
+    /*
+     * (non-Javadoc)
+     * @see org.apache.sling.api.resource.Resource#getPath()
+     */
+    public String getPath() {
+        return path;
+    }
+
+    /*
+     * (non-Javadoc)
+     * @see org.apache.sling.api.resource.Resource#getResourceMetadata()
+     */
+    public ResourceMetadata getResourceMetadata() {
+        return metadata;
+    }
+
+    /*
+     * (non-Javadoc)
+     * @see org.apache.sling.api.resource.Resource#getResourceResolver()
+     */
+    public ResourceResolver getResourceResolver() {
+        return resourceResolver;
+    }
+
+    /*
+     * (non-Javadoc)
+     * @see org.apache.sling.api.resource.Resource#getResourceSuperType()
+     */
+    public String getResourceSuperType() {
+        return null;
+    }
+
+}

--- a/src/main/java/org/apache/sling/jackrabbit/usermanager/impl/resource/BaseResource.java
+++ b/src/main/java/org/apache/sling/jackrabbit/usermanager/impl/resource/BaseResource.java
@@ -28,7 +28,7 @@ public abstract class BaseResource extends AbstractResource {
     private final String path;
     private final ResourceMetadata metadata;
 
-    public BaseResource(ResourceResolver resourceResolver, String path) {
+    protected BaseResource(ResourceResolver resourceResolver, String path) {
         super();
 
         this.resourceResolver = resourceResolver;

--- a/src/main/java/org/apache/sling/jackrabbit/usermanager/impl/resource/PrincipalResource.java
+++ b/src/main/java/org/apache/sling/jackrabbit/usermanager/impl/resource/PrincipalResource.java
@@ -23,9 +23,7 @@ import java.util.Map;
 import org.apache.jackrabbit.api.security.principal.GroupPrincipal;
 import org.apache.sling.adapter.annotations.Adaptable;
 import org.apache.sling.adapter.annotations.Adapter;
-import org.apache.sling.api.resource.AbstractResource;
 import org.apache.sling.api.resource.Resource;
-import org.apache.sling.api.resource.ResourceMetadata;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ValueMap;
 import org.apache.sling.api.wrappers.ValueMapDecorator;
@@ -37,24 +35,16 @@ import org.apache.sling.api.wrappers.ValueMapDecorator;
     @Adapter({Map.class, ValueMap.class, Principal.class}),
     @Adapter(condition="If the resource is an PrincipalResource and represents a JCR principal", value = Principal.class)
 })
-public class PrincipalResource extends AbstractResource {
-    protected final ResourceResolver resourceResolver;
+public class PrincipalResource extends BaseResource {
     protected final Principal principal;
-    private final String path;
     private final String resourceType;
-    private final ResourceMetadata metadata;
 
     public PrincipalResource(Principal principal,
             ResourceResolver resourceResolver, String path) {
-        super();
+        super(resourceResolver, path);
 
-        this.resourceResolver = resourceResolver;
         this.principal = principal;
-        this.path = path;
         this.resourceType = toResourceType(principal);
-
-        this.metadata = new ResourceMetadata();
-        metadata.setResolutionPath(path);
     }
 
     /**
@@ -68,38 +58,6 @@ public class PrincipalResource extends AbstractResource {
         } else {
             return "sling/user";
         }
-    }
-
-    /*
-     * (non-Javadoc)
-     * @see org.apache.sling.api.resource.Resource#getPath()
-     */
-    public String getPath() {
-        return path;
-    }
-
-    /*
-     * (non-Javadoc)
-     * @see org.apache.sling.api.resource.Resource#getResourceMetadata()
-     */
-    public ResourceMetadata getResourceMetadata() {
-        return metadata;
-    }
-
-    /*
-     * (non-Javadoc)
-     * @see org.apache.sling.api.resource.Resource#getResourceResolver()
-     */
-    public ResourceResolver getResourceResolver() {
-        return resourceResolver;
-    }
-
-    /*
-     * (non-Javadoc)
-     * @see org.apache.sling.api.resource.Resource#getResourceSuperType()
-     */
-    public String getResourceSuperType() {
-        return null;
     }
 
     /*
@@ -134,4 +92,5 @@ public class PrincipalResource extends AbstractResource {
         return getClass().getSimpleName() + ", id=" + id + ", path="
             + getPath();
     }
+
 }

--- a/src/main/java/org/apache/sling/jackrabbit/usermanager/impl/resource/PrincipalResource.java
+++ b/src/main/java/org/apache/sling/jackrabbit/usermanager/impl/resource/PrincipalResource.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.sling.jackrabbit.usermanager.impl.resource;
+
+import java.security.Principal;
+import java.util.Collections;
+import java.util.Map;
+
+import org.apache.jackrabbit.api.security.principal.GroupPrincipal;
+import org.apache.sling.adapter.annotations.Adaptable;
+import org.apache.sling.adapter.annotations.Adapter;
+import org.apache.sling.api.resource.AbstractResource;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceMetadata;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.api.resource.ValueMap;
+import org.apache.sling.api.wrappers.ValueMapDecorator;
+
+/**
+ * Resource implementation for Principal (SLING-11098)
+ */
+@Adaptable(adaptableClass = Resource.class, adapters = {
+    @Adapter({Map.class, ValueMap.class, Principal.class}),
+    @Adapter(condition="If the resource is an PrincipalResource and represents a JCR principal", value = Principal.class)
+})
+public class PrincipalResource extends AbstractResource {
+    protected final ResourceResolver resourceResolver;
+    protected final Principal principal;
+    private final String path;
+    private final String resourceType;
+    private final ResourceMetadata metadata;
+
+    public PrincipalResource(Principal principal,
+            ResourceResolver resourceResolver, String path) {
+        super();
+
+        this.resourceResolver = resourceResolver;
+        this.principal = principal;
+        this.path = path;
+        this.resourceType = toResourceType(principal);
+
+        this.metadata = new ResourceMetadata();
+        metadata.setResolutionPath(path);
+    }
+
+    /**
+     * determine the resource type for the principal.
+     * @param principal the principal to consider
+     * @return the resource type
+     */
+    protected String toResourceType(Principal principal) {
+        if (principal instanceof GroupPrincipal) {
+            return "sling/group";
+        } else {
+            return "sling/user";
+        }
+    }
+
+    /*
+     * (non-Javadoc)
+     * @see org.apache.sling.api.resource.Resource#getPath()
+     */
+    public String getPath() {
+        return path;
+    }
+
+    /*
+     * (non-Javadoc)
+     * @see org.apache.sling.api.resource.Resource#getResourceMetadata()
+     */
+    public ResourceMetadata getResourceMetadata() {
+        return metadata;
+    }
+
+    /*
+     * (non-Javadoc)
+     * @see org.apache.sling.api.resource.Resource#getResourceResolver()
+     */
+    public ResourceResolver getResourceResolver() {
+        return resourceResolver;
+    }
+
+    /*
+     * (non-Javadoc)
+     * @see org.apache.sling.api.resource.Resource#getResourceSuperType()
+     */
+    public String getResourceSuperType() {
+        return null;
+    }
+
+    /*
+     * (non-Javadoc)
+     * @see org.apache.sling.api.resource.Resource#getResourceType()
+     */
+    public String getResourceType() {
+        return resourceType;
+    }
+
+    /*
+     * (non-Javadoc)
+     * @see org.apache.sling.api.adapter.Adaptable#adaptTo(java.lang.Class)
+     */
+    @Override
+    public <T> T adaptTo(Class<T> type) {
+        if (type == Map.class || type == ValueMap.class) {
+            ValueMap valueMap = new ValueMapDecorator(Collections.emptyMap());
+            return type.cast(valueMap);
+        } else if (type == Principal.class) {
+            return type.cast(principal);
+        }
+
+        return super.adaptTo(type);
+    }
+
+    public String toString() {
+        String id = null;
+        if (principal != null) {
+            id = principal.getName();
+        }
+        return getClass().getSimpleName() + ", id=" + id + ", path="
+            + getPath();
+    }
+}

--- a/src/test/java/org/apache/sling/jcr/jackrabbit/usermanager/it/resource/PrincipalResourcesIT.java
+++ b/src/test/java/org/apache/sling/jcr/jackrabbit/usermanager/it/resource/PrincipalResourcesIT.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.jcr.jackrabbit.usermanager.it.resource;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.security.Principal;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.Map;
+
+import javax.jcr.RepositoryException;
+
+import org.apache.jackrabbit.oak.spi.security.principal.EveryonePrincipal;
+import org.apache.sling.api.resource.LoginException;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.api.resource.ValueMap;
+import org.apache.sling.jcr.resource.api.JcrResourceConstants;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.ops4j.pax.exam.junit.PaxExam;
+import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
+import org.ops4j.pax.exam.spi.reactors.PerClass;
+
+/**
+ * SLING-11098 Basic test of AuthorizableResourceProvider component providing
+ * resources that are a Principal but not an Authorizable
+ */
+@RunWith(PaxExam.class)
+@ExamReactorStrategy(PerClass.class)
+public class PrincipalResourcesIT extends BaseAuthorizableResourcesIT {
+
+    /**
+     * Test changing the usermanager provider.root value
+     */
+    @Test
+    public void getResource() throws LoginException, RepositoryException, IOException {
+        try (ResourceResolver resourceResolver = resourceResolverFactory.getResourceResolver(Collections.singletonMap(JcrResourceConstants.AUTHENTICATION_INFO_SESSION, adminSession))) {
+            Resource resource = resourceResolver.resolve("/system/userManager/group/" + EveryonePrincipal.NAME);
+            assertNotNull(resource);
+            assertEquals(EveryonePrincipal.NAME, resource.getName());
+        }
+    }
+
+    /**
+     * Test changing the usermanager provider.root value
+     */
+    @Test
+    public void checkResourceType() throws LoginException, RepositoryException, IOException {
+        try (ResourceResolver resourceResolver = resourceResolverFactory.getResourceResolver(Collections.singletonMap(JcrResourceConstants.AUTHENTICATION_INFO_SESSION, adminSession))) {
+            Resource resource = resourceResolver.resolve("/system/userManager/group/" + EveryonePrincipal.NAME);
+            assertNotNull(resource);
+            assertTrue("Expected resource type of sling/group for: " + resource.getPath(),
+                    resource.isResourceType("sling/group"));
+        }
+    }
+
+    /**
+     * Test iteration of the usermanager groups resource children
+     */
+    @Test
+    public void listGroupsChildren() throws LoginException, RepositoryException, IOException {
+        try (ResourceResolver resourceResolver = resourceResolverFactory.getResourceResolver(Collections.singletonMap(JcrResourceConstants.AUTHENTICATION_INFO_SESSION, adminSession))) {
+            Resource resource = resourceResolver.resolve("/system/userManager/group");
+            assertTrue("Expected resource type of sling/groups for: " + resource.getPath(),
+                    resource.isResourceType("sling/groups"));
+
+            boolean foundGroup = false;
+            @NotNull
+            Iterable<Resource> children = resource.getChildren();
+            for (Iterator<Resource> iterator = children.iterator(); iterator.hasNext();) {
+                Resource child = (Resource) iterator.next();
+                if (child.isResourceType("sling/group") && EveryonePrincipal.NAME.equals(child.getName())) {
+                    foundGroup = true;
+                }
+            }
+            assertTrue(foundGroup);
+        }
+    }
+
+    @Test
+    public void adaptResourceToMap() throws LoginException, RepositoryException  {
+        try (ResourceResolver resourceResolver = resourceResolverFactory.getResourceResolver(Collections.singletonMap(JcrResourceConstants.AUTHENTICATION_INFO_SESSION, adminSession))) {
+            Resource groupResource = resourceResolver.resolve(String.format("%s%s", userManagerPaths.getGroupPrefix(), EveryonePrincipal.NAME));
+            @Nullable
+            Map<?, ?> groupMap = groupResource.adaptTo(Map.class);
+            assertNotNull(groupMap);
+            assertTrue(groupMap.isEmpty());
+        }
+    }
+
+    @Test
+    public void adaptResourceToValueMap() throws LoginException, RepositoryException  {
+        try (ResourceResolver resourceResolver = resourceResolverFactory.getResourceResolver(Collections.singletonMap(JcrResourceConstants.AUTHENTICATION_INFO_SESSION, adminSession))) {
+            Resource groupResource = resourceResolver.resolve(String.format("%s%s", userManagerPaths.getGroupPrefix(), EveryonePrincipal.NAME));
+            @Nullable
+            ValueMap groupMap = groupResource.adaptTo(ValueMap.class);
+            assertNotNull(groupMap);
+            assertTrue(groupMap.isEmpty());
+        }
+    }
+
+    @Test
+    public void adaptResourceToPrincipal() throws LoginException, RepositoryException  {
+        try (ResourceResolver resourceResolver = resourceResolverFactory.getResourceResolver(Collections.singletonMap(JcrResourceConstants.AUTHENTICATION_INFO_SESSION, adminSession))) {
+            Resource groupResource = resourceResolver.resolve(String.format("%s%s", userManagerPaths.getGroupPrefix(), EveryonePrincipal.NAME));
+            @Nullable
+            Principal groupPrincipal = groupResource.adaptTo(Principal.class);
+            assertNotNull(groupPrincipal);
+            assertEquals(EveryonePrincipal.NAME, groupPrincipal.getName());
+        }
+    }
+
+    /**
+     * For code coverage, test some adaption that falls through to the super class impl
+     */
+    @Test
+    public void adaptResourceToSomethingElse() throws LoginException, RepositoryException  {
+        try (ResourceResolver resourceResolver = resourceResolverFactory.getResourceResolver(Collections.singletonMap(JcrResourceConstants.AUTHENTICATION_INFO_SESSION, adminSession))) {
+            Resource groupResource = resourceResolver.resolve(String.format("%s%s", userManagerPaths.getGroupPrefix(), EveryonePrincipal.NAME));
+            @Nullable
+            NestedAuthorizableResourcesIT groupObj = groupResource.adaptTo(NestedAuthorizableResourcesIT.class);
+            assertNull(groupObj);
+        }
+    }
+
+}


### PR DESCRIPTION
Some principals like the everyone group don't have a corresponding Authorizable.  The existing AuthorizableResourceProvider implementation does not provide a resource for that principal.

So for the use case where UserManager#getAuthorizable returns null but the PrincipalManager#getPrincipal returns non-null then we should have a PrincipalResource instead of skipping it.