### PR TITLE
SLING-11242 Update dependency for sling.api v2.25.0 compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.api</artifactId>
-            <version>2.24.0</version>
+            <version>2.25.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/test/java/org/apache/sling/jcr/jackrabbit/usermanager/it/UserManagerTestSupport.java
+++ b/src/test/java/org/apache/sling/jcr/jackrabbit/usermanager/it/UserManagerTestSupport.java
@@ -130,12 +130,14 @@ public abstract class UserManagerTestSupport extends TestSupport {
         // newer version of sling.api and dependencies for SLING-10034
         //   may remove at a later date if the superclass includes these versions or later
         versionResolver.setVersionFromProject("org.apache.sling", "org.apache.sling.api");
-        versionResolver.setVersion("org.apache.sling", "org.apache.sling.engine", "2.7.10"); // to be compatible with current o.a.sling.api
+        versionResolver.setVersion("org.apache.sling", "org.apache.sling.engine", "2.9.0"); // to be compatible with current o.a.sling.api
         versionResolver.setVersion("org.apache.sling", "org.apache.sling.resourceresolver", "1.8.0"); // to be compatible with current o.a.sling.api
         versionResolver.setVersion("org.apache.sling", "org.apache.sling.scripting.core", "2.4.0"); // to be compatible with current o.a.sling.api
         versionResolver.setVersion("org.apache.sling", "org.apache.sling.scripting.api", "2.2.0"); // to be compatible with current o.a.sling.api
-        versionResolver.setVersion("org.apache.sling", "org.apache.sling.servlets.resolver", "2.9.0"); // to be compatible with current o.a.sling.api
+        versionResolver.setVersion("org.apache.sling", "org.apache.sling.servlets.resolver", "2.9.4"); // to be compatible with current o.a.sling.api
         versionResolver.setVersion("org.apache.sling", "org.apache.sling.commons.compiler", "2.4.0"); // to be compatible with current o.a.sling.scripting.core
+        versionResolver.setVersion("org.apache.sling", "org.apache.sling.auth.core", "1.5.4"); // to be compatible with current o.a.sling.engine
+        versionResolver.setVersion("commons-codec", "commons-codec", "1.13"); // to be compatible with current o.a.sling.auth.core
 
         return composite(
             super.baseConfiguration(),


### PR DESCRIPTION
Resolves this error:

`[ERROR] [bundle-packages] org.apache.sling:org.apache.sling.jcr.jackrabbit.usermanager:2.2.18: Bundle is importing package org.apache.sling.api.request;version=[2.5,2.6) with start order 20 but no bundle is exporting these for that start order in the required version range.`

