### PR TITLE
SLING-12007 upgrade parent POM

### DIFF
--- a/bnd.bnd
+++ b/bnd.bnd
@@ -1,7 +1,6 @@
 
 -includeresource:\
-  @org.apache.sling.servlets.post-*.jar!/org/apache/sling/servlets/post/impl/helper/(RequestProperty*|DateParser*),\
-  ${project.build.directory}/adapter-plugin-generated
+  @org.apache.sling.servlets.post-*.jar!/org/apache/sling/servlets/post/impl/helper/(RequestProperty*|DateParser*)
 
 -removeheaders:\
   Include-Resource,\

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.sling</groupId>
         <artifactId>sling-bundle-parent</artifactId>
-        <version>49</version>
+        <version>52</version>
         <relativePath />
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -166,7 +166,7 @@
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
-            <artifactId>osgi.core</artifactId>
+            <artifactId>org.osgi.framework</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -261,9 +261,9 @@
           <scope>test</scope>
         </dependency>
         <dependency>
-          <groupId>org.osgi</groupId>
-          <artifactId>osgi.cmpn</artifactId>
-          <scope>test</scope>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.service.cm</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
           <groupId>org.slf4j</groupId>
@@ -281,6 +281,13 @@
             <artifactId>org.apache.felix.healthcheck.api</artifactId>
             <version>2.0.4</version>
             <scope>test</scope>
+            <exclusions>
+                <!-- workaround to exclude the banned aggregate artifact -->
+                <exclusion>
+                    <groupId>org.osgi</groupId>
+                    <artifactId>osgi.core</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
        <dependency>
             <groupId>org.awaitility</groupId>


### PR DESCRIPTION
fixes Reproducible Builds issues: `depends-maven-plugin` is upgraded in this parent release