### PR TITLE
SLING-12106 Bump dependencies to the earliest versions without known vulnerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,7 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.servlets.post</artifactId>
-            <version>2.3.8</version>
+            <version>2.3.22</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -153,7 +153,7 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.jcr.base</artifactId>
-            <version>2.0.6</version>
+            <version>3.1.12</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/org/apache/sling/jackrabbit/usermanager/impl/post/AbstractAuthorizablePostServlet.java
+++ b/src/main/java/org/apache/sling/jackrabbit/usermanager/impl/post/AbstractAuthorizablePostServlet.java
@@ -719,10 +719,13 @@ public abstract class AbstractAuthorizablePostServlet extends
         } else {
             if (type == PropertyType.DATE) {
                 // try conversion
-                ValueFactory valFac = session.getValueFactory();
-                Value[] c = dateParser.parse(values, valFac);
+                Calendar[] c = dateParser.parse(values);
                 if (c != null) {
-                    parent.setProperty(relativePath, c);
+                    ValueFactory vf = session.getValueFactory();
+                    Value[] cVals = Stream.of(c)
+                            .map(vf::createValue)
+                            .toArray(Value[]::new);
+                    parent.setProperty(relativePath, cVals);
                     changes.add(Modification.onModified(parentPath + "/"
                         + relativePath));
                     return;

--- a/src/main/java/org/apache/sling/jackrabbit/usermanager/impl/post/AbstractAuthorizablePostServlet.java
+++ b/src/main/java/org/apache/sling/jackrabbit/usermanager/impl/post/AbstractAuthorizablePostServlet.java
@@ -141,7 +141,9 @@ public abstract class AbstractAuthorizablePostServlet extends
     /**
      * Get or generate the name of the principal being created
      * 
-     * @param request the current request
+     * @param jcrSession the JCR session
+     * @param properties the properties to consider when generating a name
+     * @param type the type of authorizable
      * @return the principal name
      */
     protected String getOrGeneratePrincipalName(Session jcrSession, Map<String, ?> properties, AuthorizableType type) throws RepositoryException {

--- a/src/main/java/org/apache/sling/jackrabbit/usermanager/impl/post/ChangeUserPasswordServlet.java
+++ b/src/main/java/org/apache/sling/jackrabbit/usermanager/impl/post/ChangeUserPasswordServlet.java
@@ -55,8 +55,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
+ * <h2>
+ * Changes the password associated with a user.
+ * </h2>
  * <p>
- * Changes the password associated with a user. Maps on to nodes of resourceType <code>sling/user</code> like
+ * Maps on to nodes of resourceType <code>sling/user</code> like
  * <code>/rep:system/rep:userManager/rep:users/ae/fd/3e/ieb</code> mapped to a resource url
  * <code>/system/userManager/user/ieb</code>. This servlet responds at
  * <code>/system/userManager/user/ieb.changePassword.html</code>

--- a/src/main/java/org/apache/sling/jackrabbit/usermanager/impl/post/PrincipalNameGeneratorImpl.java
+++ b/src/main/java/org/apache/sling/jackrabbit/usermanager/impl/post/PrincipalNameGeneratorImpl.java
@@ -41,6 +41,7 @@ import org.osgi.service.metatype.annotations.ObjectClassDefinition;
  * <p>
  * The value is resolved by the locating the first request parameter that is a 
  * match of one of the choices in the following order:
+ * </p>
  * <ol>
  * <li>":name" - value is the exact name to use</li>
  * <li>":name@ValueFrom" - value is the name of another submitted parameter whose value is the exact name to use</li>
@@ -48,7 +49,6 @@ import org.osgi.service.metatype.annotations.ObjectClassDefinition;
  * <li>":nameHint@ValueFrom" - value is the name of another submitted parameter whose value is filtered, trimmed and made unique</li>
  * <li>otherwise, try the value of any configured "principalNameHints" parameters to treat as a hint that is filtered, trimmed and made unique</li>
  * </ol>
- * </p>
  */
 @Component(
         configurationPid = "org.apache.sling.jackrabbit.usermanager.PrincipalNameGenerator",
@@ -189,10 +189,10 @@ public class PrincipalNameGeneratorImpl implements PrincipalNameGenerator {
     /**
      * Get a "nice" principal name, if possible, based on given request
      *
-     * @param request request
+     * @param parameters the properties to consider when generating a name
      * @param type the type of principal
+     * @param principalNameFilter the filter to make a value work as a principal name
      * @param defaultPrincipalNameGenerator the default principal name generator
-     *
      * @return the principal name to be created or null if other PrincipalNameGenerators should be consulted
      */
     @Override


### PR DESCRIPTION
Mostly to keep tooling from flagging these as "vulnerabilities from dependencies"

1. bump org.apache.sling.servlets.post to 2.3.22
2. bump org.apache.sling.jcr.base to 3.1.12