### PR TITLE
SLING-12185 AuthorizableResourceProvider matches wrong prefix

### DIFF
--- a/src/test/java/org/apache/sling/jcr/jackrabbit/usermanager/it/resource/AuthorizableResourceProviderIT.java
+++ b/src/test/java/org/apache/sling/jcr/jackrabbit/usermanager/it/resource/AuthorizableResourceProviderIT.java
@@ -338,4 +338,19 @@ public class AuthorizableResourceProviderIT extends BaseAuthorizableResourcesIT 
         }
     }
 
+    /**
+     * Test to verify the fix for SLING-12185
+     */
+    @Test
+    public void getResourceWithWrongPathPrefix() throws LoginException, RepositoryException {
+        createResourcesForAdaptTo();
+
+        try (ResourceResolver resourceResolver = resourceResolverFactory.getResourceResolver(Collections.singletonMap(JcrResourceConstants.AUTHENTICATION_INFO_SESSION, adminSession))) {
+            Resource groupResource = resourceResolver.getResource(String.format("%s%s", userManagerPaths.getUserPrefix(), group1.getID()));
+            assertNull(groupResource);
+
+            Resource userResource = resourceResolver.getResource(String.format("%s%s", userManagerPaths.getGroupPrefix(), user1.getID()));
+            assertNull(userResource);
+        }
+    }
 }


### PR DESCRIPTION
resourceResolver.getResource("/userManager/user/group1") returns a resource object  when it should return null because the path of the group resource is actually "/userManager/group/group1"

Expected: check the type of the found Authorizable to ensure that the object type matches the expected resource path prefix

