### PR TITLE
SLING-12202 add canChangePasswordWithoutOldPassword

### DIFF
--- a/src/main/java/org/apache/sling/jackrabbit/usermanager/AuthorizablePrivilegesInfo.java
+++ b/src/main/java/org/apache/sling/jackrabbit/usermanager/AuthorizablePrivilegesInfo.java
@@ -18,6 +18,8 @@ package org.apache.sling.jackrabbit.usermanager;
 
 import javax.jcr.Session;
 
+import org.jetbrains.annotations.NotNull;
+
 public interface AuthorizablePrivilegesInfo {
 
     /**
@@ -168,6 +170,20 @@ public interface AuthorizablePrivilegesInfo {
      */
     default boolean canChangePassword(Session jcrSession,
             String userId) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Checks whether the current user has been granted privileges
+     * to change the password of the specified user without knowing
+     * the current password of the user.
+     *
+     * @param jcrSession the JCR session of the current user
+     * @param userId the user id to check
+     * @return true if the current user has the privileges, false otherwise
+     */
+    default boolean canChangePasswordWithoutOldPassword(@NotNull Session jcrSession,
+            @NotNull String userId) {
         throw new UnsupportedOperationException();
     }
 

--- a/src/main/java/org/apache/sling/jackrabbit/usermanager/impl/AuthorizablePrivilegesInfoImpl.java
+++ b/src/main/java/org/apache/sling/jackrabbit/usermanager/impl/AuthorizablePrivilegesInfoImpl.java
@@ -395,15 +395,19 @@ public class AuthorizablePrivilegesInfoImpl implements AuthorizablePrivilegesInf
             // can't change your own password without the old password
             if (!jcrSession.getUserID().equals(userId)) {
                 UserManager um = AccessControlUtil.getUserManager(jcrSession);
-                User currentUser = um.getAuthorizable(jcrSession.getUserID(), User.class);
-                User targetUser = um.getAuthorizable(userId, User.class);
-                //system users and anonymous have no passwords
-                if (!targetUser.isSystemUser() && !"anonymous".equals(targetUser.getID())) {
-                    if (currentUser.isAdmin()) {
-                        can = true;
-                    } else if (userAdminGroupName != null) {
-                        Group group = um.getAuthorizable(userAdminGroupName, Group.class);
-                        can = group.isMember(currentUser);
+                Authorizable currentUser = um.getAuthorizable(jcrSession.getUserID());
+                if (currentUser instanceof User) {
+                    Authorizable targetUser = um.getAuthorizable(userId);
+                    //system users and anonymous have no passwords
+                    if (targetUser instanceof User && !((User)targetUser).isSystemUser() && !"anonymous".equals(targetUser.getID())) {
+                        if (((User)currentUser).isAdmin()) {
+                            can = true;
+                        } else if (userAdminGroupName != null) {
+                            Authorizable group = um.getAuthorizable(userAdminGroupName);
+                            if (group instanceof Group) {
+                                can = ((Group)group).isMember(currentUser);
+                            }
+                        }
                     }
                 }
             }

--- a/src/main/java/org/apache/sling/jackrabbit/usermanager/impl/AuthorizablePrivilegesInfoImpl.java
+++ b/src/main/java/org/apache/sling/jackrabbit/usermanager/impl/AuthorizablePrivilegesInfoImpl.java
@@ -37,6 +37,7 @@ import org.apache.sling.jackrabbit.usermanager.AuthorizablePrivilegesInfo;
 import org.apache.sling.jackrabbit.usermanager.ChangeUserPassword;
 import org.apache.sling.jackrabbit.usermanager.CreateUser;
 import org.apache.sling.jcr.base.util.AccessControlUtil;
+import org.jetbrains.annotations.NotNull;
 import org.osgi.framework.BundleContext;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
@@ -98,6 +99,7 @@ public class AuthorizablePrivilegesInfoImpl implements AuthorizablePrivilegesInf
     private String groupsPath;
     private boolean selfRegistrationEnabled;
     private boolean allowSelfChangePassword = false;
+    private String userAdminGroupName;
 
     @Reference(cardinality=ReferenceCardinality.OPTIONAL, policy = ReferencePolicy.DYNAMIC)
     private void bindChangeUserPassword(ChangeUserPassword changeUserPassword, Map<String, Object> properties) {
@@ -108,6 +110,8 @@ public class AuthorizablePrivilegesInfoImpl implements AuthorizablePrivilegesInf
         } else {
             allowSelfChangePassword = OsgiUtil.toBoolean(properties.get("allowSelfChangePassword"), false);
         }
+
+        userAdminGroupName = OsgiUtil.toString(properties.get(PAR_USER_ADMIN_GROUP_NAME), DEFAULT_USER_ADMIN_GROUP_NAME);
     }
     @SuppressWarnings("unused")
     private void unbindChangeUserPassword(ChangeUserPassword changeUserPassword, Map<String, Object> properties) {
@@ -380,6 +384,39 @@ public class AuthorizablePrivilegesInfoImpl implements AuthorizablePrivilegesInf
         }
         return hasRights;
     }
+
+    /* (non-Javadoc)
+     * @see org.apache.sling.jackrabbit.usermanager.AuthorizablePrivilegesInfo#canChangePasswordWithoutOldPassword(javax.jcr.Session, java.lang.String)
+     */
+    @Override
+    public boolean canChangePasswordWithoutOldPassword(@NotNull Session jcrSession, @NotNull String userId) {
+        boolean can = false;
+        try {
+            // can't change your own password without the old password
+            if (!jcrSession.getUserID().equals(userId)) {
+                UserManager um = AccessControlUtil.getUserManager(jcrSession);
+                Authorizable authorizable = um.getAuthorizable(jcrSession.getUserID());
+                if (authorizable instanceof User) {
+                    Authorizable targetUser = um.getAuthorizable(userId);
+                    //system users and anonymous have no passwords
+                    if (targetUser instanceof User && !((User)targetUser).isSystemUser() && !"anonymous".equals(targetUser.getID())) {
+                        if (((User)authorizable).isAdmin()) {
+                            can = true;
+                        } else if (userAdminGroupName != null) {
+                            Authorizable group = um.getAuthorizable(userAdminGroupName);
+                            if (group instanceof Group) {
+                                can = ((Group)group).isMember(authorizable);
+                            }
+                        }
+                    }
+                }
+            }
+        } catch (RepositoryException e) {
+            log.warn("Failed to determine if {} is a user admin", userId);
+        }
+        return can;
+    }
+
 
     // ---------- SCR Integration ----------------------------------------------
 

--- a/src/main/java/org/apache/sling/jackrabbit/usermanager/impl/AuthorizablePrivilegesInfoImpl.java
+++ b/src/main/java/org/apache/sling/jackrabbit/usermanager/impl/AuthorizablePrivilegesInfoImpl.java
@@ -395,19 +395,15 @@ public class AuthorizablePrivilegesInfoImpl implements AuthorizablePrivilegesInf
             // can't change your own password without the old password
             if (!jcrSession.getUserID().equals(userId)) {
                 UserManager um = AccessControlUtil.getUserManager(jcrSession);
-                Authorizable authorizable = um.getAuthorizable(jcrSession.getUserID());
-                if (authorizable instanceof User) {
-                    Authorizable targetUser = um.getAuthorizable(userId);
-                    //system users and anonymous have no passwords
-                    if (targetUser instanceof User && !((User)targetUser).isSystemUser() && !"anonymous".equals(targetUser.getID())) {
-                        if (((User)authorizable).isAdmin()) {
-                            can = true;
-                        } else if (userAdminGroupName != null) {
-                            Authorizable group = um.getAuthorizable(userAdminGroupName);
-                            if (group instanceof Group) {
-                                can = ((Group)group).isMember(authorizable);
-                            }
-                        }
+                User currentUser = um.getAuthorizable(jcrSession.getUserID(), User.class);
+                User targetUser = um.getAuthorizable(userId, User.class);
+                //system users and anonymous have no passwords
+                if (!targetUser.isSystemUser() && !"anonymous".equals(targetUser.getID())) {
+                    if (currentUser.isAdmin()) {
+                        can = true;
+                    } else if (userAdminGroupName != null) {
+                        Group group = um.getAuthorizable(userAdminGroupName, Group.class);
+                        can = group.isMember(currentUser);
                     }
                 }
             }
@@ -422,13 +418,13 @@ public class AuthorizablePrivilegesInfoImpl implements AuthorizablePrivilegesInf
 
     @Activate
     protected void activate(BundleContext bundleContext, Map<String, Object> properties) {
-        String userAdminGroupName = OsgiUtil.toString(properties.get(PAR_USER_ADMIN_GROUP_NAME), null);
-        if ( userAdminGroupName != null && ! DEFAULT_USER_ADMIN_GROUP_NAME.equals(userAdminGroupName)) {
+        String deprecatedUserAdminGroupName = OsgiUtil.toString(properties.get(PAR_USER_ADMIN_GROUP_NAME), null);
+        if ( deprecatedUserAdminGroupName != null && ! DEFAULT_USER_ADMIN_GROUP_NAME.equals(deprecatedUserAdminGroupName)) {
             log.warn("Configuration setting for {} is deprecated and will not have any effect", PAR_USER_ADMIN_GROUP_NAME);
         }
 
-        String groupAdminGroupName = OsgiUtil.toString(properties.get(PAR_GROUP_ADMIN_GROUP_NAME), null);
-        if ( groupAdminGroupName != null && ! DEFAULT_GROUP_ADMIN_GROUP_NAME.equals(userAdminGroupName)) {
+        String deprecatedGroupAdminGroupName = OsgiUtil.toString(properties.get(PAR_GROUP_ADMIN_GROUP_NAME), null);
+        if ( deprecatedGroupAdminGroupName != null && ! DEFAULT_GROUP_ADMIN_GROUP_NAME.equals(deprecatedUserAdminGroupName)) {
             log.warn("Configuration setting for {} is deprecated and will not have any effect", PAR_GROUP_ADMIN_GROUP_NAME);
         }
     }

--- a/src/main/java/org/apache/sling/jackrabbit/usermanager/package-info.java
+++ b/src/main/java/org/apache/sling/jackrabbit/usermanager/package-info.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-@org.osgi.annotation.versioning.Version("2.5.0")
+@org.osgi.annotation.versioning.Version("2.6.0")
 package org.apache.sling.jackrabbit.usermanager;
 
 

--- a/src/test/java/org/apache/sling/jackrabbit/usermanager/AuthorizablePrivilegesInfoTest.java
+++ b/src/test/java/org/apache/sling/jackrabbit/usermanager/AuthorizablePrivilegesInfoTest.java
@@ -18,6 +18,8 @@ package org.apache.sling.jackrabbit.usermanager;
 
 import static org.junit.Assert.*;
 
+import javax.jcr.Session;
+
 import org.apache.sling.jackrabbit.usermanager.AuthorizablePrivilegesInfo.PropertyUpdateTypes;
 import org.junit.Test;
 
@@ -25,6 +27,38 @@ import org.junit.Test;
  * Test coverage for AuthorizablePrivilegesInfo / PropertyUpdateTypes
  */
 public class AuthorizablePrivilegesInfoTest {
+
+    /**
+     * An implementation to facilitate testing of default methods in the interface
+     */
+    public static class TestDefaultMethodsAuthorizablePrivlegesInfo implements AuthorizablePrivilegesInfo {
+
+        @Override
+        public boolean canAddUser(Session jcrSession) {
+            return false;
+        }
+
+        @Override
+        public boolean canAddGroup(Session jcrSession) {
+            return false;
+        }
+
+        @Override
+        public boolean canUpdateProperties(Session jcrSession, String principalId) {
+            return false;
+        }
+
+        @Override
+        public boolean canRemove(Session jcrSession, String principalId) {
+            return false;
+        }
+
+        @Override
+        public boolean canUpdateGroupMembers(Session jcrSession, String groupId) {
+            return false;
+        }
+
+    }
 
     @SuppressWarnings("deprecation")
     @Test
@@ -36,6 +70,47 @@ public class AuthorizablePrivilegesInfoTest {
 
         //and one that doesn't require conversion
         assertEquals(PropertyUpdateTypes.REMOVE_PROPERTY, PropertyUpdateTypes.convertDeprecated(PropertyUpdateTypes.REMOVE_PROPERTY));
+    }
+
+
+    /**
+     * Test method for {@link org.apache.sling.jackrabbit.usermanager.AuthorizablePrivilegesInfo#canUpdateProperties(javax.jcr.Session, java.lang.String, org.apache.sling.jackrabbit.usermanager.AuthorizablePrivilegesInfo.PropertyUpdateTypes[])}.
+     */
+    @Test(expected = UnsupportedOperationException.class)
+    public void testCanUpdatePropertiesSessionStringPropertyUpdateTypesArray() {
+        AuthorizablePrivilegesInfo api = new TestDefaultMethodsAuthorizablePrivlegesInfo();
+        Session jcrSession = null;
+        api.canUpdateProperties(jcrSession, "testuser1", PropertyUpdateTypes.ALTER_PROPERTY);
+    }
+
+    /**
+     * Test method for {@link org.apache.sling.jackrabbit.usermanager.AuthorizablePrivilegesInfo#canDisable(javax.jcr.Session, java.lang.String)}.
+     */
+    @Test(expected = UnsupportedOperationException.class)
+    public void testCanDisable() {
+        AuthorizablePrivilegesInfo api = new TestDefaultMethodsAuthorizablePrivlegesInfo();
+        Session jcrSession = null;
+        api.canDisable(jcrSession, "testuser1");
+    }
+
+    /**
+     * Test method for {@link org.apache.sling.jackrabbit.usermanager.AuthorizablePrivilegesInfo#canChangePassword(javax.jcr.Session, java.lang.String)}.
+     */
+    @Test(expected = UnsupportedOperationException.class)
+    public void testCanChangePassword() {
+        AuthorizablePrivilegesInfo api = new TestDefaultMethodsAuthorizablePrivlegesInfo();
+        Session jcrSession = null;
+        api.canChangePassword(jcrSession, "testuser1");
+    }
+
+    /**
+     * Test method for {@link org.apache.sling.jackrabbit.usermanager.AuthorizablePrivilegesInfo#canChangePasswordWithoutOldPassword(javax.jcr.Session, java.lang.String)}.
+     */
+    @Test(expected = UnsupportedOperationException.class)
+    public void testCanChangePasswordWithoutOldPassword() {
+        AuthorizablePrivilegesInfo api = new TestDefaultMethodsAuthorizablePrivlegesInfo();
+        Session jcrSession = null;
+        api.canChangePasswordWithoutOldPassword(jcrSession, "testuser1");
     }
 
 }


### PR DESCRIPTION
The AuthorizablePrivilegesInfo should have a canChangePasswordWithoutOldPassword method that can be called to tell if the current user can change the password of another user without knowing the original password of that user.  This currently means the current user must the be the admin user or a member of the configured UserAdmin group.

This would be a convenience so that "change password" UI can more easily determine the appropriate fields to render on screen without having to duplicate logic from the ChangeUserPasswordServlet.