### PR TITLE
SLING-12203 Remove dependency on org.apache.sling.jcr.base

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -151,12 +151,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.sling</groupId>
-            <artifactId>org.apache.sling.jcr.base</artifactId>
-            <version>3.1.12</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>javax.jcr</groupId>
             <artifactId>jcr</artifactId>
             <scope>provided</scope>

--- a/src/main/java/org/apache/sling/jackrabbit/usermanager/impl/AuthorizablePrivilegesInfoImpl.java
+++ b/src/main/java/org/apache/sling/jackrabbit/usermanager/impl/AuthorizablePrivilegesInfoImpl.java
@@ -25,6 +25,7 @@ import javax.jcr.Session;
 import javax.jcr.security.AccessControlManager;
 import javax.jcr.security.Privilege;
 
+import org.apache.jackrabbit.api.JackrabbitSession;
 import org.apache.jackrabbit.api.security.user.Authorizable;
 import org.apache.jackrabbit.api.security.user.Group;
 import org.apache.jackrabbit.api.security.user.User;
@@ -36,7 +37,6 @@ import org.apache.sling.commons.osgi.OsgiUtil;
 import org.apache.sling.jackrabbit.usermanager.AuthorizablePrivilegesInfo;
 import org.apache.sling.jackrabbit.usermanager.ChangeUserPassword;
 import org.apache.sling.jackrabbit.usermanager.CreateUser;
-import org.apache.sling.jcr.base.util.AccessControlUtil;
 import org.jetbrains.annotations.NotNull;
 import org.osgi.framework.BundleContext;
 import org.osgi.service.component.annotations.Activate;
@@ -144,7 +144,7 @@ public class AuthorizablePrivilegesInfoImpl implements AuthorizablePrivilegesInf
     public boolean canAddGroup(Session jcrSession) {
         boolean hasRights = false;
         try {
-            UserManager userManager = AccessControlUtil.getUserManager(jcrSession);
+            UserManager userManager = ((JackrabbitSession)jcrSession).getUserManager();
             Authorizable currentUser = userManager.getAuthorizable(jcrSession.getUserID());
 
             if (currentUser instanceof User && ((User)currentUser).isAdmin()) {
@@ -178,7 +178,7 @@ public class AuthorizablePrivilegesInfoImpl implements AuthorizablePrivilegesInf
             if (selfRegistrationEnabled) {
                 hasRights = true;
             } else {
-                UserManager userManager = AccessControlUtil.getUserManager(jcrSession);
+                UserManager userManager = ((JackrabbitSession)jcrSession).getUserManager();
                 Authorizable currentUser = userManager.getAuthorizable(jcrSession.getUserID());
                 if (currentUser instanceof User && ((User)currentUser).isAdmin()) {
                     hasRights = true;  //admin user has full control
@@ -205,7 +205,7 @@ public class AuthorizablePrivilegesInfoImpl implements AuthorizablePrivilegesInf
     protected boolean checkAuthorizablePath(Session jcrSession, String principalId,
             AuthorizableChecker authorizableChecker, AccessChecker accessChecker) throws RepositoryException {
         boolean hasRights = false;
-        UserManager userManager = AccessControlUtil.getUserManager(jcrSession);
+        UserManager userManager = ((JackrabbitSession)jcrSession).getUserManager();
         Authorizable currentUser = userManager.getAuthorizable(jcrSession.getUserID());
 
         Authorizable authorizable = userManager.getAuthorizable(principalId);
@@ -394,7 +394,7 @@ public class AuthorizablePrivilegesInfoImpl implements AuthorizablePrivilegesInf
         try {
             // can't change your own password without the old password
             if (!jcrSession.getUserID().equals(userId)) {
-                UserManager um = AccessControlUtil.getUserManager(jcrSession);
+                UserManager um = ((JackrabbitSession)jcrSession).getUserManager();
                 Authorizable currentUser = um.getAuthorizable(jcrSession.getUserID());
                 if (currentUser instanceof User) {
                     Authorizable targetUser = um.getAuthorizable(userId);

--- a/src/main/java/org/apache/sling/jackrabbit/usermanager/impl/post/AbstractAuthorizablePostServlet.java
+++ b/src/main/java/org/apache/sling/jackrabbit/usermanager/impl/post/AbstractAuthorizablePostServlet.java
@@ -39,6 +39,7 @@ import javax.jcr.nodetype.NodeType;
 import javax.jcr.nodetype.PropertyDefinition;
 
 import org.apache.jackrabbit.JcrConstants;
+import org.apache.jackrabbit.api.JackrabbitSession;
 import org.apache.jackrabbit.api.security.user.Authorizable;
 import org.apache.jackrabbit.api.security.user.UserManager;
 import org.apache.jackrabbit.oak.spi.security.user.AuthorizableType;
@@ -49,7 +50,6 @@ import org.apache.sling.jackrabbit.usermanager.PrincipalNameFilter;
 import org.apache.sling.jackrabbit.usermanager.PrincipalNameGenerator;
 import org.apache.sling.jackrabbit.usermanager.PrincipalNameGenerator.NameInfo;
 import org.apache.sling.jackrabbit.usermanager.resource.SystemUserManagerPaths;
-import org.apache.sling.jcr.base.util.AccessControlUtil;
 import org.apache.sling.servlets.post.Modification;
 import org.apache.sling.servlets.post.SlingPostConstants;
 import org.apache.sling.servlets.post.impl.helper.DateParser;
@@ -168,7 +168,7 @@ public abstract class AbstractAuthorizablePostServlet extends
                 principalName = nameInfo.getPrincipalName();
                 if (principalName != null && nameInfo.isMakeUnique()) {
                     // make sure the name is not already used
-                    UserManager um = AccessControlUtil.getUserManager(jcrSession);
+                    UserManager um = ((JackrabbitSession)jcrSession).getUserManager();
 
                     // if resulting authorizable exists, add a random suffix until it's not the case
                     // anymore

--- a/src/main/java/org/apache/sling/jackrabbit/usermanager/impl/post/AbstractGroupPostServlet.java
+++ b/src/main/java/org/apache/sling/jackrabbit/usermanager/impl/post/AbstractGroupPostServlet.java
@@ -22,12 +22,12 @@ import java.util.Map;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 
+import org.apache.jackrabbit.api.JackrabbitSession;
 import org.apache.jackrabbit.api.security.user.Authorizable;
 import org.apache.jackrabbit.api.security.user.Group;
 import org.apache.jackrabbit.api.security.user.UserManager;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
-import org.apache.sling.jcr.base.util.AccessControlUtil;
 import org.apache.sling.servlets.post.Modification;
 import org.apache.sling.servlets.post.SlingPostConstants;
 
@@ -62,7 +62,7 @@ public abstract class AbstractGroupPostServlet extends
             ResourceResolver resolver = baseResource.getResourceResolver();
             boolean changed = false;
             
-            UserManager userManager = AccessControlUtil.getUserManager(resolver.adaptTo(Session.class));
+            UserManager userManager = ((JackrabbitSession)resolver.adaptTo(Session.class)).getUserManager();
 
             // first remove any members posted as ":member@Delete"
             String[] membersToDelete = convertToStringArray(properties.get(SlingPostConstants.RP_PREFIX

--- a/src/main/java/org/apache/sling/jackrabbit/usermanager/impl/post/ChangeUserPasswordServlet.java
+++ b/src/main/java/org/apache/sling/jackrabbit/usermanager/impl/post/ChangeUserPasswordServlet.java
@@ -25,6 +25,7 @@ import javax.jcr.security.AccessControlManager;
 import javax.jcr.security.Privilege;
 import javax.servlet.Servlet;
 
+import org.apache.jackrabbit.api.JackrabbitSession;
 import org.apache.jackrabbit.api.security.user.Authorizable;
 import org.apache.jackrabbit.api.security.user.Group;
 import org.apache.jackrabbit.api.security.user.User;
@@ -37,7 +38,6 @@ import org.apache.sling.commons.osgi.OsgiUtil;
 import org.apache.sling.jackrabbit.usermanager.ChangeUserPassword;
 import org.apache.sling.jackrabbit.usermanager.resource.SystemUserManagerPaths;
 import org.apache.sling.jcr.api.SlingRepository;
-import org.apache.sling.jcr.base.util.AccessControlUtil;
 import org.apache.sling.serviceusermapping.ServiceUserMapped;
 import org.apache.sling.servlets.post.Modification;
 import org.apache.sling.servlets.post.PostResponse;
@@ -258,7 +258,7 @@ public class ChangeUserPasswordServlet extends AbstractAuthorizablePostServlet i
         }
 
         User user;
-        UserManager userManager = AccessControlUtil.getUserManager(jcrSession);
+        UserManager userManager = ((JackrabbitSession)jcrSession).getUserManager();
         Authorizable authorizable = userManager.getAuthorizable(name);
         if (authorizable instanceof User) {
             user = (User)authorizable;
@@ -274,7 +274,7 @@ public class ChangeUserPasswordServlet extends AbstractAuthorizablePostServlet i
         // check that the submitted parameter values have valid values.
         if (oldPassword == null || oldPassword.length() == 0) {
             try {
-                UserManager um = AccessControlUtil.getUserManager(jcrSession);
+                UserManager um = ((JackrabbitSession)jcrSession).getUserManager();
                 User currentUser = (User) um.getAuthorizable(jcrSession.getUserID());
                 administrator = currentUser.isAdmin();
 
@@ -324,7 +324,7 @@ public class ChangeUserPasswordServlet extends AbstractAuthorizablePostServlet i
                     Session svcSession = null;
                     try {
                         svcSession = repository.loginService(null, null);
-                        UserManager um = AccessControlUtil.getUserManager(svcSession);
+                        UserManager um = ((JackrabbitSession)svcSession).getUserManager();
                         User user2 = (User) um.getAuthorizable(name);
                         user2.changePassword(newPassword, oldPassword);
                         if (svcSession.hasPendingChanges()) {

--- a/src/main/java/org/apache/sling/jackrabbit/usermanager/impl/post/CreateGroupServlet.java
+++ b/src/main/java/org/apache/sling/jackrabbit/usermanager/impl/post/CreateGroupServlet.java
@@ -25,6 +25,7 @@ import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 import javax.servlet.Servlet;
 
+import org.apache.jackrabbit.api.JackrabbitSession;
 import org.apache.jackrabbit.api.security.user.Authorizable;
 import org.apache.jackrabbit.api.security.user.Group;
 import org.apache.jackrabbit.api.security.user.UserManager;
@@ -38,7 +39,6 @@ import org.apache.sling.jackrabbit.usermanager.CreateGroup;
 import org.apache.sling.jackrabbit.usermanager.PrincipalNameFilter;
 import org.apache.sling.jackrabbit.usermanager.PrincipalNameGenerator;
 import org.apache.sling.jackrabbit.usermanager.resource.SystemUserManagerPaths;
-import org.apache.sling.jcr.base.util.AccessControlUtil;
 import org.apache.sling.servlets.post.Modification;
 import org.apache.sling.servlets.post.PostResponse;
 import org.apache.sling.servlets.post.PostResponseCreator;
@@ -235,7 +235,7 @@ public class CreateGroupServlet extends AbstractGroupPostServlet implements Crea
             throw new IllegalArgumentException("Group name was not supplied");
         }
 
-        UserManager userManager = AccessControlUtil.getUserManager(jcrSession);
+        UserManager userManager = ((JackrabbitSession)jcrSession).getUserManager();
         Authorizable authorizable = userManager.getAuthorizable(principalName);
 
         Group group = null;

--- a/src/main/java/org/apache/sling/jackrabbit/usermanager/impl/post/CreateUserServlet.java
+++ b/src/main/java/org/apache/sling/jackrabbit/usermanager/impl/post/CreateUserServlet.java
@@ -26,6 +26,7 @@ import javax.jcr.security.AccessControlManager;
 import javax.jcr.security.Privilege;
 import javax.servlet.Servlet;
 
+import org.apache.jackrabbit.api.JackrabbitSession;
 import org.apache.jackrabbit.api.security.user.Authorizable;
 import org.apache.jackrabbit.api.security.user.User;
 import org.apache.jackrabbit.api.security.user.UserManager;
@@ -39,7 +40,6 @@ import org.apache.sling.jackrabbit.usermanager.PrincipalNameFilter;
 import org.apache.sling.jackrabbit.usermanager.PrincipalNameGenerator;
 import org.apache.sling.jackrabbit.usermanager.resource.SystemUserManagerPaths;
 import org.apache.sling.jcr.api.SlingRepository;
-import org.apache.sling.jcr.base.util.AccessControlUtil;
 import org.apache.sling.serviceusermapping.ServiceUserMapped;
 import org.apache.sling.servlets.post.Modification;
 import org.apache.sling.servlets.post.ModificationType;
@@ -321,7 +321,7 @@ public class CreateUserServlet extends AbstractAuthorizablePostServlet implement
         // check for an administrator
         boolean administrator = false;
         try {
-            UserManager um = AccessControlUtil.getUserManager(jcrSession);
+            UserManager um = ((JackrabbitSession)jcrSession).getUserManager();
             User currentUser = (User) um.getAuthorizable(jcrSession.getUserID());
             administrator = currentUser.isAdmin();
 
@@ -372,7 +372,7 @@ public class CreateUserServlet extends AbstractAuthorizablePostServlet implement
                 selfRegSession = getSession();
             }
 
-            UserManager userManager = AccessControlUtil.getUserManager(selfRegSession);
+            UserManager userManager = ((JackrabbitSession)selfRegSession).getUserManager();
             Authorizable authorizable = userManager.getAuthorizable(principalName);
 
             if (authorizable != null) {
@@ -402,7 +402,7 @@ public class CreateUserServlet extends AbstractAuthorizablePostServlet implement
 
                 if (useAdminSession) {
                     //lookup the user from the user session so we can return a live object
-                    UserManager userManager2 = AccessControlUtil.getUserManager(jcrSession);
+                    UserManager userManager2 = ((JackrabbitSession)jcrSession).getUserManager();
                     Authorizable authorizable2 = userManager2.getAuthorizable(user.getID());
                     if (authorizable2 instanceof User) {
                         user = (User)authorizable2;

--- a/src/main/java/org/apache/sling/jackrabbit/usermanager/impl/post/DeleteAuthorizableServlet.java
+++ b/src/main/java/org/apache/sling/jackrabbit/usermanager/impl/post/DeleteAuthorizableServlet.java
@@ -26,6 +26,7 @@ import javax.jcr.Session;
 import javax.servlet.Servlet;
 import javax.servlet.http.HttpServletResponse;
 
+import org.apache.jackrabbit.api.JackrabbitSession;
 import org.apache.jackrabbit.api.security.user.Authorizable;
 import org.apache.jackrabbit.api.security.user.Group;
 import org.apache.jackrabbit.api.security.user.User;
@@ -38,7 +39,6 @@ import org.apache.sling.jackrabbit.usermanager.DeleteAuthorizables;
 import org.apache.sling.jackrabbit.usermanager.DeleteGroup;
 import org.apache.sling.jackrabbit.usermanager.DeleteUser;
 import org.apache.sling.jackrabbit.usermanager.resource.SystemUserManagerPaths;
-import org.apache.sling.jcr.base.util.AccessControlUtil;
 import org.apache.sling.servlets.post.Modification;
 import org.apache.sling.servlets.post.PostResponse;
 import org.apache.sling.servlets.post.PostResponseCreator;
@@ -163,7 +163,7 @@ public class DeleteAuthorizableServlet extends AbstractPostServlet
             List<Modification> changes) throws RepositoryException {
 
         User user;
-        UserManager userManager = AccessControlUtil.getUserManager(jcrSession);
+        UserManager userManager = ((JackrabbitSession)jcrSession).getUserManager();
         Authorizable authorizable = userManager.getAuthorizable(name);
         if (authorizable instanceof User) {
             user = (User)authorizable;
@@ -186,7 +186,7 @@ public class DeleteAuthorizableServlet extends AbstractPostServlet
                             List<Modification> changes) throws RepositoryException {
 
         Group group;
-        UserManager userManager = AccessControlUtil.getUserManager(jcrSession);
+        UserManager userManager = ((JackrabbitSession)jcrSession).getUserManager();
         Authorizable authorizable = userManager.getAuthorizable(name);
         if (authorizable instanceof Group) {
             group = (Group)authorizable;

--- a/src/main/java/org/apache/sling/jackrabbit/usermanager/impl/post/UpdateGroupServlet.java
+++ b/src/main/java/org/apache/sling/jackrabbit/usermanager/impl/post/UpdateGroupServlet.java
@@ -25,6 +25,7 @@ import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 import javax.servlet.Servlet;
 
+import org.apache.jackrabbit.api.JackrabbitSession;
 import org.apache.jackrabbit.api.security.user.Authorizable;
 import org.apache.jackrabbit.api.security.user.Group;
 import org.apache.jackrabbit.api.security.user.UserManager;
@@ -36,7 +37,6 @@ import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ResourceResolverFactory;
 import org.apache.sling.jackrabbit.usermanager.UpdateGroup;
 import org.apache.sling.jackrabbit.usermanager.resource.SystemUserManagerPaths;
-import org.apache.sling.jcr.base.util.AccessControlUtil;
 import org.apache.sling.jcr.resource.api.JcrResourceConstants;
 import org.apache.sling.servlets.post.Modification;
 import org.apache.sling.servlets.post.PostResponse;
@@ -180,7 +180,7 @@ public class UpdateGroupServlet extends AbstractGroupPostServlet
             throws RepositoryException {
 
         Group group = null;
-        UserManager userManager = AccessControlUtil.getUserManager(jcrSession);
+        UserManager userManager = ((JackrabbitSession)jcrSession).getUserManager();
         Authorizable authorizable = userManager.getAuthorizable(name);
         if (authorizable instanceof Group) {
             group = (Group)authorizable;

--- a/src/main/java/org/apache/sling/jackrabbit/usermanager/impl/post/UpdateUserServlet.java
+++ b/src/main/java/org/apache/sling/jackrabbit/usermanager/impl/post/UpdateUserServlet.java
@@ -24,6 +24,7 @@ import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 import javax.servlet.Servlet;
 
+import org.apache.jackrabbit.api.JackrabbitSession;
 import org.apache.jackrabbit.api.security.user.Authorizable;
 import org.apache.jackrabbit.api.security.user.User;
 import org.apache.jackrabbit.api.security.user.UserManager;
@@ -32,7 +33,6 @@ import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceNotFoundException;
 import org.apache.sling.jackrabbit.usermanager.UpdateUser;
 import org.apache.sling.jackrabbit.usermanager.resource.SystemUserManagerPaths;
-import org.apache.sling.jcr.base.util.AccessControlUtil;
 import org.apache.sling.servlets.post.Modification;
 import org.apache.sling.servlets.post.PostResponse;
 import org.apache.sling.servlets.post.PostResponseCreator;
@@ -170,7 +170,7 @@ public class UpdateUserServlet extends AbstractAuthorizablePostServlet
             throws RepositoryException {
 
         User user;
-        UserManager userManager = AccessControlUtil.getUserManager(jcrSession);
+        UserManager userManager = ((JackrabbitSession)jcrSession).getUserManager();
         Authorizable authorizable = userManager.getAuthorizable(name);
         if (authorizable instanceof User) {
             user = (User)authorizable;

--- a/src/main/java/org/apache/sling/jackrabbit/usermanager/impl/resource/AuthorizableResourceProvider.java
+++ b/src/main/java/org/apache/sling/jackrabbit/usermanager/impl/resource/AuthorizableResourceProvider.java
@@ -26,6 +26,7 @@ import java.util.NoSuchElementException;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 
+import org.apache.jackrabbit.api.JackrabbitSession;
 import org.apache.jackrabbit.api.security.principal.GroupPrincipal;
 import org.apache.jackrabbit.api.security.principal.PrincipalIterator;
 import org.apache.jackrabbit.api.security.principal.PrincipalManager;
@@ -39,7 +40,6 @@ import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.SyntheticResource;
 import org.apache.sling.commons.osgi.OsgiUtil;
 import org.apache.sling.jackrabbit.usermanager.resource.SystemUserManagerPaths;
-import org.apache.sling.jcr.base.util.AccessControlUtil;
 import org.apache.sling.spi.resource.provider.ResolveContext;
 import org.apache.sling.spi.resource.provider.ResourceContext;
 import org.apache.sling.spi.resource.provider.ResourceProvider;
@@ -253,7 +253,7 @@ public class AuthorizableResourceProvider extends ResourceProvider<Object> imple
             Session session = ctx.getResourceResolver().adaptTo(Session.class);
             if (session != null) {
                 try {
-                    UserManager userManager = AccessControlUtil.getUserManager(session);
+                    UserManager userManager = ((JackrabbitSession)session).getUserManager();
                     if (userManager != null) {
                         Authorizable authorizable = userManager.getAuthorizable(pid);
                         if (authorizable != null) {
@@ -262,7 +262,7 @@ public class AuthorizableResourceProvider extends ResourceProvider<Object> imple
                             }
                         } else if (principalWorker != null && relPath == null){
                             // SLING-11098 check for a principal that is not an authorizable like the everyone group
-                            PrincipalManager principalManager = AccessControlUtil.getPrincipalManager(session);
+                            PrincipalManager principalManager = ((JackrabbitSession)session).getPrincipalManager();
                             if (principalManager != null) {
                                 @Nullable
                                 Principal principal = principalManager.getPrincipal(pid);
@@ -324,7 +324,7 @@ public class AuthorizableResourceProvider extends ResourceProvider<Object> imple
                 ResourceResolver resourceResolver = parent.getResourceResolver();
                 Session session = resourceResolver.adaptTo(Session.class);
                 if (session != null) {
-                    PrincipalManager principalManager = AccessControlUtil.getPrincipalManager(session);
+                    PrincipalManager principalManager = ((JackrabbitSession)session).getPrincipalManager();
                     principals = principalManager.getPrincipals(searchType);
                 }
 
@@ -428,7 +428,7 @@ public class AuthorizableResourceProvider extends ResourceProvider<Object> imple
         protected @Nullable Resource createNext(Object child, String principalName,
                 ResourceResolver resourceResolver, Session session) throws RepositoryException {
             Resource next = null;
-            UserManager userManager = AccessControlUtil.getUserManager(session);
+            UserManager userManager = ((JackrabbitSession)session).getUserManager();
             if (userManager != null) {
                 Authorizable authorizable = userManager.getAuthorizable(principalName);
                 if (authorizable != null) {
@@ -512,7 +512,7 @@ public class AuthorizableResourceProvider extends ResourceProvider<Object> imple
             Resource next = super.createNext(child, principalName, resourceResolver, session);
             if (next == null) {
                 // SLING-11098 check for principal that is not authorizable
-                PrincipalManager principalManager = AccessControlUtil.getPrincipalManager(session);
+                PrincipalManager principalManager = ((JackrabbitSession)session).getPrincipalManager();
                 if (principalManager != null) {
                     @Nullable
                     Principal principal = principalManager.getPrincipal(principalName);

--- a/src/test/java/org/apache/sling/jcr/jackrabbit/usermanager/it/AuthorizablePrivilegesInfoIT.java
+++ b/src/test/java/org/apache/sling/jcr/jackrabbit/usermanager/it/AuthorizablePrivilegesInfoIT.java
@@ -55,7 +55,6 @@ import org.apache.sling.jackrabbit.usermanager.DeleteUser;
 import org.apache.sling.jackrabbit.usermanager.UpdateGroup;
 import org.apache.sling.jackrabbit.usermanager.UpdateUser;
 import org.apache.sling.jcr.api.SlingRepository;
-import org.apache.sling.jcr.base.util.AccessControlUtil;
 import org.apache.sling.jcr.jackrabbit.accessmanager.DeleteAces;
 import org.apache.sling.jcr.jackrabbit.accessmanager.ModifyAce;
 import org.junit.After;
@@ -786,7 +785,7 @@ public class AuthorizablePrivilegesInfoIT extends UserManagerTestSupport {
             deleteUser.deleteUser(user1Session, user2Id, new ArrayList<>());
             user2 = null;
             // verify the user is no longer there
-            UserManager um = AccessControlUtil.getUserManager(user1Session);
+            UserManager um = ((JackrabbitSession)user1Session).getUserManager();
             assertNull("Expected user to be gone: " + user2Id, um.getAuthorizable(user2Id));
 
             // verify that the user can actually delete the group


### PR DESCRIPTION
Remove dependency on org.apache.sling.jcr.base since it is only used for AccessControlUtil methods to access the UserManager and PrincipalManager. 

Since this bundle is a jackrabbit/oak specific implementation we can use the JackrabbitSession methods to accomplish the same without the dependency.